### PR TITLE
Fix: insecure tmp file

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,11 +8,13 @@
         "@actions/github": "^6.0.1",
         "@octokit/rest": "^22.0.0",
         "@octokit/webhooks-types": "^7.6.1",
+        "tmp": "^0.2.3",
         "ts-dedent": "^2.2.0",
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
         "@types/bun": "latest",
+        "@types/tmp": "^0.2.0",
         "@typescript-eslint/eslint-plugin": "^8.34.1",
         "@typescript-eslint/parser": "^8.34.1",
         "eslint": "^9.29.0",
@@ -103,6 +105,8 @@
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/node": ["@types/node@22.15.30", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA=="],
+
+    "@types/tmp": ["@types/tmp@0.2.6", "", {}, "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.34.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.34.1", "@typescript-eslint/type-utils": "8.34.1", "@typescript-eslint/utils": "8.34.1", "@typescript-eslint/visitor-keys": "8.34.1", "graphemer": "^1.4.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.34.1", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.9.0" } }, "sha512-STXcN6ebF6li4PxwNeFnqF8/2BNDvBupf2OPx2yWNzr6mKNGF7q49VM00Pz5FaomJyqvbXpY6PhO+T9w139YEQ=="],
 
@@ -289,6 +293,8 @@
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "tmp": ["tmp@0.2.4", "", {}, "sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@eslint/js": "^9.29.0",
     "@types/bun": "latest",
+    "@types/tmp": "^0.2.0",
     "@typescript-eslint/eslint-plugin": "^8.34.1",
     "@typescript-eslint/parser": "^8.34.1",
     "eslint": "^9.29.0",
@@ -28,6 +29,7 @@
     "@actions/github": "^6.0.1",
     "@octokit/rest": "^22.0.0",
     "@octokit/webhooks-types": "^7.6.1",
+    "tmp": "^0.2.3",
     "ts-dedent": "^2.2.0"
   }
 }

--- a/src/core/data/utils/file-downloader.ts
+++ b/src/core/data/utils/file-downloader.ts
@@ -15,6 +15,7 @@
 
 import fs from "fs/promises";
 import path from "path";
+import tmp from "tmp";
 import type { Octokit } from "@octokit/rest";
 
 /**
@@ -164,7 +165,7 @@ export async function downloadCommentAttachments(
 ): Promise<Map<string, string>> {
   const {
     maxFileSize = 50 * 1024 * 1024, // 50MB default
-    downloadsDir = "/tmp/github-attachments",
+    downloadsDir = tmp.dirSync({ unsafeCleanup: true }).name,
   } = options;
 
   const urlToPathMap = new Map<string, string>();

--- a/tests/file-downloader.test.ts
+++ b/tests/file-downloader.test.ts
@@ -78,6 +78,9 @@ describe("downloadCommentAttachments", () => {
       "owner",
       "repo",
       comments,
+      {
+        downloadsDir: "/tmp/github-attachments",
+      },
     );
 
     expect(fsMkdirSpy).toHaveBeenCalledWith("/tmp/github-attachments", {
@@ -100,6 +103,9 @@ describe("downloadCommentAttachments", () => {
       "owner",
       "repo",
       comments,
+      {
+        downloadsDir: "/tmp/github-attachments",
+      },
     );
 
     expect(result.size).toBe(0);
@@ -144,6 +150,9 @@ describe("downloadCommentAttachments", () => {
       "owner",
       "repo",
       comments,
+      {
+        downloadsDir: "/tmp/github-attachments",
+      },
     );
 
     expect(mockOctokit.rest.issues.getComment).toHaveBeenCalledWith({
@@ -210,6 +219,9 @@ describe("downloadCommentAttachments", () => {
       "owner",
       "repo",
       comments,
+      {
+        downloadsDir: "/tmp/github-attachments",
+      },
     );
 
     expect(mockOctokit.rest.issues.getComment).toHaveBeenCalledWith({
@@ -273,6 +285,9 @@ describe("downloadCommentAttachments", () => {
       "owner",
       "repo",
       comments,
+      {
+        downloadsDir: "/tmp/github-attachments",
+      },
     );
 
     expect(mockOctokit.rest.pulls.getReviewComment).toHaveBeenCalledWith({
@@ -321,6 +336,9 @@ describe("downloadCommentAttachments", () => {
       "owner",
       "repo",
       comments,
+      {
+        downloadsDir: "/tmp/github-attachments",
+      },
     );
 
     expect(mockOctokit.rest.pulls.getReview).toHaveBeenCalledWith({
@@ -369,6 +387,9 @@ describe("downloadCommentAttachments", () => {
       "owner",
       "repo",
       comments,
+      {
+        downloadsDir: "/tmp/github-attachments",
+      },
     );
 
     expect(mockOctokit.rest.issues.get).toHaveBeenCalledWith({
@@ -418,6 +439,9 @@ describe("downloadCommentAttachments", () => {
       "owner",
       "repo",
       comments,
+      {
+        downloadsDir: "/tmp/github-attachments",
+      },
     );
 
     expect(mockOctokit.rest.pulls.get).toHaveBeenCalledWith({
@@ -471,6 +495,9 @@ describe("downloadCommentAttachments", () => {
       "owner",
       "repo",
       comments,
+      {
+        downloadsDir: "/tmp/github-attachments",
+      },
     );
 
     expect(fetchSpy).toHaveBeenCalledTimes(2);
@@ -523,6 +550,9 @@ describe("downloadCommentAttachments", () => {
       "owner",
       "repo",
       comments,
+      {
+        downloadsDir: "/tmp/github-attachments",
+      },
     );
 
     expect(fetchSpy).toHaveBeenCalledTimes(1); // Only downloaded once
@@ -556,6 +586,9 @@ describe("downloadCommentAttachments", () => {
       "owner",
       "repo",
       comments,
+      {
+        downloadsDir: "/tmp/github-attachments",
+      },
     );
 
     expect(result.size).toBe(0);
@@ -598,6 +631,9 @@ describe("downloadCommentAttachments", () => {
       "owner",
       "repo",
       comments,
+      {
+        downloadsDir: "/tmp/github-attachments",
+      },
     );
 
     expect(result.size).toBe(0);
@@ -628,6 +664,9 @@ describe("downloadCommentAttachments", () => {
       "owner",
       "repo",
       comments,
+      {
+        downloadsDir: "/tmp/github-attachments",
+      },
     );
 
     expect(result.size).toBe(0);
@@ -670,6 +709,9 @@ describe("downloadCommentAttachments", () => {
       "owner",
       "repo",
       comments,
+      {
+        downloadsDir: "/tmp/github-attachments",
+      },
     );
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -713,6 +755,9 @@ describe("downloadCommentAttachments", () => {
       "owner",
       "repo",
       comments,
+      {
+        downloadsDir: "/tmp/github-attachments",
+      },
     );
 
     expect(fetchSpy).toHaveBeenCalledTimes(0);
@@ -755,7 +800,10 @@ describe("downloadCommentAttachments", () => {
       "owner",
       "repo",
       comments,
-      { maxFileSize: 0 },
+      {
+        maxFileSize: 0,
+        downloadsDir: "/tmp/github-attachments",
+      },
     );
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Changed the tmp directory to be created by the `tmp` package by default.

Resolves #97 