### PR TITLE
Fix: GitHub markdown

### DIFF
--- a/src/core/response/prompt.ts
+++ b/src/core/response/prompt.ts
@@ -145,7 +145,8 @@ function createAgentInstructionPromptForComment(
 
     Please respond and execute actions according to the user's instruction.
 
-    Output your response in the following format - Ensure to use Github Flavored Markdown for the response (correct whitespace usage):
+    Format your response using GitHub Flavored Markdown with clean spacing. Keep one blank line between all block elements (headings, paragraphs, lists, tables, code blocks, etc.).
+
     ## ⚡️ TL;DR
     - Purpose: quick, scannable overview of the task
     - Maximum 2 sentences


### PR DESCRIPTION
Modified prompt to specify the fact we need to use Github flavoured markdown to render the comment correctly.

Resolves #152 