### PR TITLE
Remove full api response from logs for extra security

### DIFF
--- a/src/core/services/h2ogpte/h2ogpte.ts
+++ b/src/core/services/h2ogpte/h2ogpte.ts
@@ -38,9 +38,7 @@ export async function createAgentKey(
   );
 
   const data = (await response.json()) as types.AgentKey;
-  console.debug(
-    `Successfully created agent keys with id: ${data.id}`,
-  );
+  console.debug(`Successfully created agent keys with id: ${data.id}`);
 
   return data.id;
 }
@@ -76,9 +74,7 @@ export async function createToolAssociation(
   );
 
   const data = (await response.json()) as types.ToolAssociations;
-  console.debug(
-    `Successfully created tool association`,
-  );
+  console.debug(`Successfully created tool association`);
 
   return data;
 }
@@ -110,9 +106,7 @@ export async function createChatSession(
   );
 
   const data = (await response.json()) as types.ChatSession;
-  console.debug(
-    `Successfully created chat session with id: ${data.id}`,
-  );
+  console.debug(`Successfully created chat session with id: ${data.id}`);
 
   return data;
 }
@@ -265,9 +259,7 @@ export async function createCollection(
 
   const data = (await response.json()) as types.Collection;
 
-  console.debug(
-    `Successfully created collection with id: ${data.id}`,
-  );
+  console.debug(`Successfully created collection with id: ${data.id}`);
 
   return data.id;
 }


### PR DESCRIPTION
## Issue

Submitting this quick fix to remove leaky logs. Previously, we output the entire response from h2ogpte which may cause our customers to become worried about logs leaking sensitive information.

## Solution

Only log key fields of the response, i.e. the `id`.