### PR TITLE
Extract Final Response Handles all Markdown Heading Levels for TL;DR

### DIFF
--- a/src/core/response/utils/extract-response.ts
+++ b/src/core/response/utils/extract-response.ts
@@ -1,7 +1,8 @@
 /**
  * Pattern to match the TL;DR header that indicates the final response section
+ * Matches any markdown header level (1-6 #) with TL;DR
  */
-const PATTERN_TLDR_HEADER = /^##\s+.*TL;DR/im;
+const PATTERN_TLDR_HEADER = /^#{1,6}\s+.*TL;DR.*/im;
 
 /**
  * Substring to check for max turns reached message

--- a/tests/response/extract-response.test.ts
+++ b/tests/response/extract-response.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { extractFinalAgentResponse } from "../../src/core/response/utils/extract-response";
 
 describe("extractFinalAgentResponse", () => {
@@ -270,6 +270,24 @@ ENDOFTURN`;
     const result = extractFinalAgentResponse(input);
     expect(result).toBe(
       "## TL;DR Summary\nThis should still match the pattern.\n## Details\nMore content here.",
+    );
+  });
+
+  test("should extract single header TL;DR (# instead of ##)", () => {
+    const input = `
+ENDOFTURN
+
+# ⚡️ TL;DR
+Summary with single header.
+
+## Details
+More content here.
+
+<stream_turn_title>Summary</stream_turn_title>
+ENDOFTURN`;
+    const result = extractFinalAgentResponse(input);
+    expect(result).toBe(
+      "# ⚡️ TL;DR\nSummary with single header.\n## Details\nMore content here.",
     );
   });
 


### PR DESCRIPTION
This PR is a quick fix for https://github.com/h2oai/h2ogpte-action/issues/195#issuecomment-3471286305

The main issue is that the agent outputted `# ⚡️ TL;DR` instead of `## ⚡️ TL;DR` which is what our regex pattern typically looks for. I've (i.e. cursor) adjusted the regex pattern to handle all levels of headings.