### PR TITLE
Fix: Parse agent response

### DIFF
--- a/src/core/response/utils/extract-response.ts
+++ b/src/core/response/utils/extract-response.ts
@@ -49,8 +49,15 @@ export function extractFinalAgentResponse(input: string): string {
     textBeforeTitle = finalSection.substring(0, titleIndex);
   }
 
+  // Remove everything before `## ⚡️ TL;DR`
+  let tlDrSection = textBeforeTitle;
+  const tlDrIndex = tlDrSection.indexOf("## ⚡️ TL;DR");
+  if (tlDrIndex !== -1) {
+    tlDrSection = tlDrSection.substring(tlDrIndex);
+  }
+
   // Remove agent metadata and clean up the whitespace in the text
-  const cleanedText = textBeforeTitle
+  const cleanedText = tlDrSection
     .replace(/\*\*Completed LLM call in.*?\*\*/g, "")
     .replace(/\*\* \[.*?\] .*?\*\*/g, "")
     .replace(/\*\*Executing python code blocks\*\*/g, "")

--- a/tests/response/extract-response.test.ts
+++ b/tests/response/extract-response.test.ts
@@ -406,4 +406,43 @@ ENDOFTURN`;
     const result = extractFinalAgentResponse(input);
     expect(result).toBe("## ⚡️ TL;DR\nSummary here.");
   });
+
+  test("should remove everything before ## ⚡️ TL;DR in the final section", () => {
+    const input = `
+ENDOFTURN
+
+Some unwanted content before TL;DR
+More unwanted text here
+Random information
+
+## ⚡️ TL;DR
+This is the actual summary.
+
+## Details
+Important details here.
+
+<stream_turn_title>Title</stream_turn_title>
+ENDOFTURN`;
+    const result = extractFinalAgentResponse(input);
+    expect(result).toBe(
+      "## ⚡️ TL;DR\nThis is the actual summary.\n## Details\nImportant details here.",
+    );
+  });
+
+  test("should remove content before ## ⚡️ TL;DR even with multiple lines", () => {
+    const input = `
+ENDOFTURN
+
+Line 1 before TL;DR
+Line 2 before TL;DR
+Line 3 before TL;DR
+
+## ⚡️ TL;DR
+The summary starts here.
+
+<stream_turn_title>Title</stream_turn_title>
+ENDOFTURN`;
+    const result = extractFinalAgentResponse(input);
+    expect(result).toBe("## ⚡️ TL;DR\nThe summary starts here.");
+  });
 });


### PR DESCRIPTION
Modified the response extraction to strip content before the expected header. This is in reaction to the changes to the API response in h2oGPTe@1.6.45. This fix ensures that the `## TL;DR` header is the first part of any h2ogpte response comment in PRs and issues.