### PR TITLE
Fix: Code block formatting

### DIFF
--- a/tests/response/extract-response.test.ts
+++ b/tests/response/extract-response.test.ts
@@ -160,7 +160,7 @@ Here is some information [citation: 1] and more details [citation:42]. Also chec
 ENDOFTURN`;
     const result = extractFinalAgentResponse(input);
     expect(result).toBe(
-      "## ⚡️ TL;DR\nHere is some information and more details . Also check this and that .",
+      "## ⚡️ TL;DR\nHere is some information and more details. Also check this and that.",
     );
   });
 
@@ -186,8 +186,7 @@ ${"   "}Some text with whitespace${"   "}
 <stream_turn_title>Title</stream_turn_title>
 ENDOFTURN`;
     const result = extractFinalAgentResponse(input);
-    // Leading whitespace is preserved, trailing whitespace is removed
-    expect(result).toBe("## ⚡️ TL;DR\n   Some text with whitespace");
+    expect(result).toBe("## ⚡️ TL;DR\n Some text with whitespace");
   });
 
   test("should handle max turns reached message", () => {


### PR DESCRIPTION
Modified the response extraction to be less aggressive with cleaning (especially whitespace). This has been handed off to github, since it does a significant amount of cleaning in the comment rendering. Tested locally to ensure it works sufficiently well with different types of whitespace combinations.

Resolves #196 