### PR TITLE
fix: github bug where banner toggle doesn't work in marketplace readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # h2oGPTe Action
 
-![h2oGPTe responding to a comment](https://raw.githubusercontent.com/h2oai/h2ogpte-action/refs/heads/main/docs/images/h2ogpte_hero_dark.png)
+![h2oGPTe responding to a comment](https://raw.githubusercontent.com/h2oai/h2ogpte-action/refs/heads/main/docs/images/h2ogpte_hero_light.png)
 
 The h2oGPTe GitHub Action brings intelligent AI assistance directly into your GitHub workflow. Simply tag `@h2ogpte` in any comment, issue, or pull request, and the agent will provide instant AI-powered code review feedback, understand your codebase context, and even write code and make commits when requested.
 


### PR DESCRIPTION
## Summary

There's an issue with GitHub's marketplace readme where the banner toggle between light and dark mode images isn't working. A ticket was raised with GitHub but it's been deprioritised by the eng team. For the moment, we can revert back to the light mode banner.