### PR TITLE
Remove prompt/agent response bias

### DIFF
--- a/src/core/response/prompt.ts
+++ b/src/core/response/prompt.ts
@@ -172,7 +172,7 @@ function createAgentInstructionPromptForComment(
     {{codeAnalysisGuidance}}
     Once you have a good understanding of the context, you can begin to respond to the user's instruction.
 
-    If necessary, include GitHub referencing (using '#' followed by the issue or PR number, e.g. #[0-9]+) when referring to any other issues or PRs. Don't respond with the literal link.
+    If necessary, reference GitHub issues or PRs using the # symbol followed by their number (e.g., #42, #123). Don't respond with the literal link.
 
     Please respond and execute actions according to the user's instruction. Remember: only make changes to the repository if the user explicitly requests it with clear action words.
 

--- a/tests/response/prompt.test.ts
+++ b/tests/response/prompt.test.ts
@@ -272,7 +272,7 @@ describe("createAgentInstructionPrompt", () => {
       const result = createAgentInstructionPrompt(context, githubData);
 
       expect(result).toContain(
-        "GitHub referencing (using '#' followed by the issue or PR number, e.g. #[0-9]+)",
+        "reference GitHub issues or PRs using the # symbol followed by their number (e.g., #42, #123)",
       );
       expect(result).toContain("Don't respond with the literal link");
     });


### PR DESCRIPTION
Removed the bias for `#23` which the agent seemingly hallucinated/referenced when there was no PR linked.