### PR TITLE
task: bump version to v0.2.2-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ See [examples](examples/) for more workflow configurations. Or, check out our [u
 
 ## ✅ Requirements
 
-h2oGPTe Action v0.2.1-beta requires h2oGPTe versions 1.6.31 through 1.6.45.
+h2oGPTe Action v0.2.2-beta requires h2oGPTe versions 1.6.31 through 1.6.47.
 
 This version range has been tested and verified for compatibility.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -28,9 +28,8 @@ The h2oGPTe GitHub Action supports several configuration options to customize th
 
 ## Compatibility
 
-Currently, only **h2ogpte version >= 1.6.31, <= 1.6.45** is supported. By default, the action uses
-`https://h2ogpte.genai.h2o.ai` as the API base. If you wish to use a different h2ogpte environment,
-you need to:
+Currently, only **h2ogpte version >= 1.6.31, <= 1.6.47** is supported. By default, the action uses
+`https://h2ogpte.genai.h2o.ai` as the API base. If you wish to use a different h2ogpte environment, you need to:
 
 1. Add your h2oGPTe server's base URL as a repository secret named `H2OGPTE_API_BASE`
 2. The action will automatically use this secret if it exists, otherwise it defaults to `https://h2ogpte.genai.h2o.ai`

--- a/examples/custom_workflows/h2ogpte_auto_docs.yaml
+++ b/examples/custom_workflows/h2ogpte_auto_docs.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: h2oGPTe Auto Docs Agent
         id: h2ogpte-agent-assistant
-        uses: h2oai/h2ogpte-action@v0.2.1-beta
+        uses: h2oai/h2ogpte-action@v0.2.2-beta
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           h2ogpte_api_key: ${{ secrets.H2OGPTE_API_KEY }}

--- a/examples/custom_workflows/h2ogpte_auto_issue_context.yaml
+++ b/examples/custom_workflows/h2ogpte_auto_issue_context.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: h2oGPTe Auto Issue Context
         id: h2ogpte-agent-assistant
-        uses: h2oai/h2ogpte-action@v0.2.1-beta
+        uses: h2oai/h2ogpte-action@v0.2.2-beta
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           h2ogpte_api_key: ${{ secrets.H2OGPTE_API_KEY }}

--- a/examples/custom_workflows/h2ogpte_auto_pr.yaml
+++ b/examples/custom_workflows/h2ogpte_auto_pr.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: h2oGPTe Auto Review Agent
         id: h2ogpte-agent-assistant
-        uses: h2oai/h2ogpte-action@v0.2.1-beta
+        uses: h2oai/h2ogpte-action@v0.2.2-beta
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           h2ogpte_api_key: ${{ secrets.H2OGPTE_API_KEY }}

--- a/examples/custom_workflows/h2ogpte_auto_test.yaml
+++ b/examples/custom_workflows/h2ogpte_auto_test.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: h2oGPTe Auto Test Generator
         id: h2ogpte-agent-assistant
-        uses: h2oai/h2ogpte-action@v0.2.1-beta
+        uses: h2oai/h2ogpte-action@v0.2.2-beta
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           h2ogpte_api_key: ${{ secrets.H2OGPTE_API_KEY }}

--- a/examples/h2ogpte.yaml
+++ b/examples/h2ogpte.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: h2oGPTe Agent Assistant
         id: h2ogpte-agent-assistant
-        uses: h2oai/h2ogpte-action@v0.2.1-beta
+        uses: h2oai/h2ogpte-action@v0.2.2-beta
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           h2ogpte_api_key: ${{ secrets.H2OGPTE_API_KEY }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h2o-ai/h2ogpte-action",
-  "version": "0.2.1-beta",
+  "version": "0.2.2-beta",
   "private": true,
   "scripts": {
     "lint": "eslint . --ext .ts,.js",


### PR DESCRIPTION
Bumped version according to the following instructions:

1. Bump the version in package.json.
2. Bump all workflows in examples/ to the corresponding tag (i.e. uses: h2oai/h2ogpte-action@{tag}). We use [Semantic Versioning 2.0.0](https://semver.org/).
3. Update the README.md and docs/CONFIGURATION.md to include the correct h2ogpte supported versions.