### PR TITLE
fix: remove slash_commands from h2ogpte.yaml

### DIFF
--- a/examples/h2ogpte.yaml
+++ b/examples/h2ogpte.yaml
@@ -43,18 +43,3 @@ jobs:
           agent_max_turns: "auto" # agent_max_turns must be one of: {"auto", 5, 10, 15, 20}
           agent_accuracy: "standard" # agent_accuracy must be one of: {"quick", "basic", "standard", "maximum"}
           agent_total_timeout: 3600 # agent_total_timeout must be a positive integer in seconds
-          slash_commands: |
-            [
-              {
-                "name": "/explain",
-                "prompt": "You are an expert software engineer and technical writer. Your job is to clearly and accurately explain code to the user.\n\nYou are given:\n1. A code snippet.\n2. A user prompt potentially containing context or questions.\n\nYour task:\n- Provide a concise but thorough explanation of what the code does.\n- Explain the logic, flow, data transformations, and intent.\n- Highlight any non-obvious behaviour, side effects, performance characteristics, or edge cases.\n- If relevant, explain how the code fits into the broader system based on the user's prompt.\n- Avoid making code changes or suggestions unless the user explicitly asks.\n- Use simple, direct language aimed at a software engineer.\n\nOutput should be easy to skim with short paragraphs, bullet points, and clear structure."
-              },
-              {
-                "name": "/review",
-                "prompt": "You are an expert software engineer performing a high-quality code review. You are given:\n1. A code snippet.\n2. A user prompt with context or goals.\n\nYour task:\n- Review the code for correctness, readability, maintainability, performance, and potential bugs.\n- Reference specific lines or behaviours when giving feedback.\n- Identify potential risks, edge cases, antipatterns, or missing tests.\n- Provide constructive, actionable feedback.\n- Suggest improvements that align with best practices and the user’s stated goals.\n- Do NOT rewrite any code unless explicitly asked.\n\nBe structured and professional. Organise feedback into sections such as 'Strengths', 'Areas for Improvement', etc."
-              },
-              {
-                "name": "/plan",
-                "prompt": "You are an expert software engineer and solution architect. You are given a user prompt describing requirements or a desired feature.\n\nYour task:\n- Produce a clear, actionable plan for how you would implement the requested functionality.\n- Break down the work into logical steps, components, or modules.\n- Cover architecture, data flow, APIs, edge cases, and testing strategy where relevant.\n- Keep the plan implementation-agnostic unless the user specifies a particular stack or language.\n- DO NOT write or modify any code.\n- DO NOT output code blocks.\n\nReturn a structured plan with headings, bullets, and concise explanations."
-              }
-            ]


### PR DESCRIPTION
Hot fix to remove slash commands from h2ogpte.yaml. Slipped my mind in #255.

The action will auto fail since 0.2.2-beta doesn't support slash commands in the input. We can add this back into 0.3.0