### PR TITLE
fix: uncaught <turn_title> tags introduced in 1.6.57-dev1

### DIFF
--- a/src/core/response/utils/extract-response.ts
+++ b/src/core/response/utils/extract-response.ts
@@ -44,9 +44,16 @@ export function extractFinalAgentResponse(input: string): string {
     return input;
   }
 
-  // Remove everything from <stream_turn_title> onwards (or trailing ENDOFTURN)
+  // Remove everything from <stream_turn_title> or <turn_title> onwards (or trailing ENDOFTURN)
   let textBeforeTitle = finalSection;
-  const titleIndex = finalSection.indexOf("<stream_turn_title>");
+  const streamTitleIndex = finalSection.indexOf("<stream_turn_title>");
+  const turnTitleIndex = finalSection.indexOf("<turn_title>");
+  const titleIndex =
+    streamTitleIndex === -1
+      ? turnTitleIndex
+      : turnTitleIndex === -1
+        ? streamTitleIndex
+        : Math.min(streamTitleIndex, turnTitleIndex);
   if (titleIndex !== -1) {
     textBeforeTitle = finalSection.substring(0, titleIndex);
   }

--- a/tests/response/extract-response.test.ts
+++ b/tests/response/extract-response.test.ts
@@ -2,6 +2,31 @@ import { describe, expect, test } from "bun:test";
 import { extractFinalAgentResponse } from "../../src/core/response/utils/extract-response";
 
 describe("extractFinalAgentResponse", () => {
+  test("should extract TL;DR section and remove turn_title", () => {
+    const input = `Some code output
+ENDOFTURN
+
+## ⚡️ TL;DR
+The repository lacks test coverage for critical components.
+
+## 🧪 Analysis
+Detailed analysis here...
+
+## 🎯 Next Steps
+- Add tests
+- Improve coverage
+
+<turn_title>Test Coverage Analysis</turn_title>
+
+**LLM Call Info:**
+Turn Time: 19.40s
+ENDOFTURN`;
+    const result = extractFinalAgentResponse(input);
+    expect(result).toBe(
+      "## ⚡️ TL;DR\nThe repository lacks test coverage for critical components.\n\n## 🧪 Analysis\nDetailed analysis here...\n\n## 🎯 Next Steps\n- Add tests\n- Improve coverage",
+    );
+  });
+
   test("should extract TL;DR section and remove stream_turn_title", () => {
     const input = `Some code output
 ENDOFTURN


### PR DESCRIPTION
## Issue

When parsing the final response from h2oGPTe we remove everything from the <stream_turn_title> tag to the trailing ENDOFTURN. In 1.6.57-dev1, a <turn_title> replaces <stream_turn_title>, resulting in extra unwanted output:

```
<turn_title>Greeting Response to @h2ogpte Mention</turn_title>

LLM Call Info:
[Wednesday, March 25, 2026 - 03:10:23.1 AM PDT]

Turn Time: 10.02s out of 120s.

Turns: 2 out of 40.
Time: 31.6 out of 3600.
Cost: Turn: $0.0380, Total: $0.1774, Remaining: $9776.63.
```

## Solution

Remove everything from <stream_turn_title> or <turnntitle> onwards (or trailing ENDOFTURN) for backwards compatibility.

## Version

Bug observed in v0.3.0-beta

## Testing

* New unit test to catch <turn_title> tags
* Integration testing completed https://github.com/MillenniumForce/h2ogpte-action/issues/12#issuecomment-4125434693