### PR TITLE
fix: change pull_request to pull_request_target in workflow

### DIFF
--- a/.github/workflows/h2ogpte.yml
+++ b/.github/workflows/h2ogpte.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited]
   issue_comment:
     types: [created, edited]
-  pull_request:
+  pull_request_target:
     types: [opened, edited]
   pull_request_review:
     types: [submitted]
@@ -22,7 +22,7 @@ jobs:
     if: |
       (github.event_name == 'issues' && contains(github.event.issue.body, '@h2ogpte')) ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@h2ogpte')) ||
-      (github.event_name == 'pull_request' && contains(github.event.pull_request.body, '@h2ogpte')) ||
+      (github.event_name == 'pull_request_target' && contains(github.event.pull_request.body, '@h2ogpte')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@h2ogpte')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@h2ogpte'))
 


### PR DESCRIPTION
## Issue

In a PR from a fork, the current `h2ogpte.yml` always fails since `pull_request` gives insufficient permissions for OIDC.

## Solution

Use `pull_request_target` to allow OIDC since it always runs in the context of the base repo (i.e. h2oai/h2ogpte-action)

## Security

In the case that we used the PR head, a fork PR could change actions and use our repositories secrets which is a serious attack vector.

However, the default checkout ref is the base ref when using `uses: ./` since the default repo of `pull_request_target` is the base repo.