### PR TITLE
chore: bump version to 0.3.1-beta and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See [examples](examples/) for more workflow configurations. Or, check out our [u
 
 ## ✅ Requirements
 
-h2oGPTe Action v0.3.0-beta requires h2oGPTe versions 1.6.46 through 1.6.57.
+h2oGPTe Action v0.3.1-beta requires h2oGPTe versions 1.6.46 through 1.6.57.
 
 This version range has been tested and verified for compatibility.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -121,6 +121,6 @@ Currently, only **h2ogpte version >= 1.6.46, <= 1.6.57** is supported. By defaul
 
 See `action.yml` for additional configuration details.
 
-[v0.3.0-beta](https://github.com/h2oai/h2ogpte-action/tree/v0.3.0-beta) supports **h2ogpte version >= 1.6.46, <= 1.6.57**.
+[v0.3.1-beta](https://github.com/h2oai/h2ogpte-action/tree/v0.3.1-beta) supports **h2ogpte version >= 1.6.46, <= 1.6.57**.
 
 To always use the latest compatible version, use `@latest`. See [FAQ](FAQ.md#-how-do-i-choose-which-version-of-the-action-to-use) for details.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h2o-ai/h2ogpte-action",
-  "version": "0.3.0-beta",
+  "version": "0.3.1-beta",
   "private": true,
   "scripts": {
     "lint": "eslint . --ext .ts,.js",


### PR DESCRIPTION
Bump version to v0.3.1-beta to cut release for #291