### PR TITLE
fix: remove links and images from agent output via h2ogpte llm args

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -247,6 +247,7 @@ export async function applyChatSettingsWithUserConfigAndTools(
     llm_args: {
       ...chatSettings.llm_args,
       use_agent: true,
+      final_answer_guidelines_mode: "detailed_no_links",
       agent_tools: agentTools,
       agent_max_turns: h2ogpteConfig.agent_max_turns,
       agent_accuracy: h2ogpteConfig.agent_accuracy,


### PR DESCRIPTION
## Summary

File links are still present in v0.3.1-beta (see: https://github.com/MillenniumForce/h2ogpte-action/issues/1#issuecomment-4336486691). Remove them using  `final_answer_guidelines_mode: detailed_no_links` in h2ogpte chat completion `llm_args`.
 
`detailed_no_links` - both files and images are withheld from the final agent response, only the chat history is used.

## Testing

All unit tests pass. See the following comment for integration testing results https://github.com/MillenniumForce/h2ogpte-action/issues/1#issuecomment-4336613043
