### PR TITLE
Bump version to v0.3.2-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See [examples](examples/) for more workflow configurations. Or, check out our [u
 
 ## ✅ Requirements
 
-h2oGPTe Action v0.3.1-beta requires h2oGPTe versions 1.6.46 through 1.6.57.
+h2oGPTe Action v0.3.2-beta requires h2oGPTe versions 1.6.46 through 1.6.59.
 
 This version range has been tested and verified for compatibility.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -113,14 +113,12 @@ If you plan to use a custom GitHub App, personal access token, or your own authe
 
 ## Compatibility
 
-Currently, only **h2ogpte version >= 1.6.46, <= 1.6.57** is supported. By default, the action uses
+Currently, only **h2ogpte version >= 1.6.46, <= 1.6.59** is supported. By default, the action uses
 `https://h2ogpte.genai.h2o.ai` as the API base. If you wish to use a different h2ogpte environment, you need to:
 
 1. Add your h2oGPTe server's base URL as a repository secret named `H2OGPTE_API_BASE`
 2. The action will automatically use this secret if it exists, otherwise it defaults to `https://h2ogpte.genai.h2o.ai`
 
 See `action.yml` for additional configuration details.
-
-[v0.3.1-beta](https://github.com/h2oai/h2ogpte-action/tree/v0.3.1-beta) supports **h2ogpte version >= 1.6.46, <= 1.6.57**.
 
 To always use the latest compatible version, use `@latest`. See [FAQ](FAQ.md#-how-do-i-choose-which-version-of-the-action-to-use) for details.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h2o-ai/h2ogpte-action",
-  "version": "0.3.1-beta",
+  "version": "0.3.2-beta",
   "private": true,
   "scripts": {
     "lint": "eslint . --ext .ts,.js",

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -247,6 +247,7 @@ export async function applyChatSettingsWithUserConfigAndTools(
     llm_args: {
       ...chatSettings.llm_args,
       use_agent: true,
+      final_answer_guidelines_mode: "detailed_no_links",
       agent_tools: agentTools,
       agent_max_turns: h2ogpteConfig.agent_max_turns,
       agent_accuracy: h2ogpteConfig.agent_accuracy,


### PR DESCRIPTION
## Summary

- Bumped version in `package.json`
- Updated h2oGPTe version compatibility in docs